### PR TITLE
Improvement - Close on save option

### DIFF
--- a/lib/gist-list-view.coffee
+++ b/lib/gist-list-view.coffee
@@ -120,7 +120,8 @@ class GistListView extends ActionSelectListView
     @client.edit(id, {files}).then((gist) ->
       atom.notifications.addSuccess(message)
     ).finally( ->
-      atom.workspace.paneForItem(editor)?.destroyItem(editor)
+      if atom.config.get('gist.closeOnSave')
+        atom.workspace.paneForItem(editor)?.destroyItem(editor)
     )
 
   cleanupGistFile: (editor) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -25,7 +25,12 @@ module.exports = AtomGist =
       type: 'string'
       default: 'GIST_ACCESS_TOKEN'
       description: 'not save the token to the configuration file'
-
+    closeOnSave:
+      order: 4
+      type: 'boolean'
+      default: false
+      description: 'close the tab when you save a gist'
+      
   activate: (state) ->
     @subscriptions = new CompositeDisposable
 


### PR DESCRIPTION
Hello, 

This has been the only thing keeping me from not using Sublime Text anymore. 

Here's a minor update / improvement, which adds the option to close the tab when you save the gist (keeping default functionality to close the tab). 

It fixes https://github.com/aki77/atom-gist/issues/3

Let me know if I've done anything wrong!
