### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,18 @@ edit `~/.atom/keymap.cson`
 
 ## Settings
 
+### [Personal Access Tokens](https://github.com/settings/tokens)
+
 * `token` (default: '')
 * `tokenFile` (default: '~/.atom/gist.token')
 * `environmentName` (default: 'GIST_ACCESS_TOKEN')
 
 [![Gyazo](http://i.gyazo.com/b68171e09b21dc06a1d50b4635b655fe.png)](http://gyazo.com/b68171e09b21dc06a1d50b4635b655fe)
 
-[Personal Access Tokens](https://github.com/settings/tokens)
+### Custom Hostname for [GitHub Enterprise](https://enterprise.github.com/features)
+
+* `hostname` (default: 'github.com/api/v3')
+* `hostnameFile` (default: '~/.atom/gist.hostname')
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ edit `~/.atom/keymap.cson`
 
 ### Custom Hostname for [GitHub Enterprise](https://enterprise.github.com/features)
 
-* `hostname` (default: 'github.com/api/v3')
-* `hostnameFile` (default: '~/.atom/gist.hostname')
+* `hostname` (default: 'api.github.com')
 
 ## Usage
 

--- a/lib/gist-client.coffee
+++ b/lib/gist-client.coffee
@@ -4,8 +4,8 @@ Promise = require 'bluebird'
 module.exports =
 class GistClient
 
-  constructor: (@token) ->
-    @client = github.client(@token).gist()
+  constructor: (@token, @hostname) ->
+    @client = github.client(@token, {"hostname": @hostname}).gist()
 
   destroy: ->
 

--- a/lib/gist-client.coffee
+++ b/lib/gist-client.coffee
@@ -5,7 +5,7 @@ module.exports =
 class GistClient
 
   constructor: (@token, @hostname) ->
-    @client = github.client(@token, {"hostname": @hostname}).gist()
+    @client = github.client(@token, {"hostname": "#{@hostname}"}).gist()
 
   destroy: ->
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -81,6 +81,15 @@ module.exports = AtomGist =
 
     atom.config.get('gist.token')
 
+  getHostname: ->
+    hostnameFile = atom.config.get('gist.hostnameFile')
+    if hostnameFile.length > 0
+      hostnameFile = untildify(hostnameFile)
+      if fs.existsSync(hostnameFile)
+        return hostname = fs.readFileSync(hostnameFile, encoding: 'utf8')?.trim()
+
+    atom.config.get('gist.hostname')
+
   getListView: ->
     GistListView ?= require './gist-list-view'
     @view ?= new GistListView(@getClient())
@@ -88,8 +97,9 @@ module.exports = AtomGist =
   getClient: ->
     GistClient ?= require './gist-client'
     unless @client?
-      @client = new GistClient(@getToken())
+      @client = new GistClient(@getToken(), @getHostname())
       console.log "gist token: #{@client.token}" if atom.config.get('gist.debug')
+      console.log "gist hostname: #{@client.hostname}" if atom.config.get('gist.debug')
     @client
 
   resetInstance: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -82,12 +82,6 @@ module.exports = AtomGist =
     atom.config.get('gist.token')
 
   getHostname: ->
-    hostnameFile = atom.config.get('gist.hostnameFile')
-    if hostnameFile.length > 0
-      hostnameFile = untildify(hostnameFile)
-      if fs.existsSync(hostnameFile)
-        return hostname = fs.readFileSync(hostnameFile, encoding: 'utf8')?.trim()
-
     atom.config.get('gist.hostname')
 
   getListView: ->

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "order": 5,
       "type": "string",
       "default": "api.github.com",
-      "description": "api endpoint, like api.github.com or myghe.com/api/v3"
+      "description": "api endpoint, like api.github.com or githubenterprise/api/v3"
     },
     "debug": {
       "order": 99,

--- a/package.json
+++ b/package.json
@@ -58,14 +58,8 @@
     "hostname": {
       "order": 5,
       "type": "string",
-      "default": "github.com/api/v3",
-      "description": "GitHub or GitHub Enterprise hostname"
-    },
-    "hostnameFile": {
-      "order": 6,
-      "type": "string",
-      "default": "~/.atom/gist.hostname",
-      "description": "not save the token to the configuration file"
+      "default": "api.github.com",
+      "description": "api endpoint, like api.github.com or myghe.com/api/v3"
     },
     "debug": {
       "order": 99,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,18 @@
       "default": false,
       "description": "close the tab when you save a gist"
     },
+    "hostname": {
+      "order": 5,
+      "type": "string",
+      "default": "github.com/api/v3",
+      "description": "GitHub or GitHub Enterprise hostname"
+    },
+    "hostnameFile": {
+      "order": 6,
+      "type": "string",
+      "default": "~/.atom/gist.hostname",
+      "description": "not save the token to the configuration file"
+    },
     "debug": {
       "order": 99,
       "type": "boolean",

--- a/spec/gist-spec.coffee
+++ b/spec/gist-spec.coffee
@@ -14,6 +14,8 @@ describe "Gist", ->
     atom.config.set('gist.token', '')
     atom.config.set('gist.tokenFile', '')
     atom.config.set('gist.environmentName', 'GIST_ACCESS_TOKEN')
+    atom.config.set('gist.hostname', '')
+    atom.config.set('gist.hostnameFile', '')
 
     waitsForPromise ->
       atom.workspace.open().then((_editor) ->
@@ -42,3 +44,20 @@ describe "Gist", ->
       expect(gistPackage.getToken()).toEqual('abc')
       process.env[atom.config.get('gist.environmentName')] = 'foo'
       expect(gistPackage.getToken()).toEqual('foo')
+
+  describe "getHostname", ->
+    beforeEach ->
+      expect(gistPackage.getHostname()).toEqual('')
+      atom.config.set('gist.hostname', 'abc')
+
+    it "gist.hostname", ->
+      expect(gistPackage.getHostname()).toEqual('abc')
+
+    it "gist.hostnameFile", ->
+      directory = temp.mkdirSync('atom-gist')
+      hostnameFile = path.join(directory, 'gist.hostname')
+      fs.writeFileSync(hostnameFile, '123')
+
+      expect(gistPackage.getHostname()).toEqual('abc')
+      atom.config.set('gist.hostnameFile', hostnameFile)
+      expect(gistPackage.getHostname()).toEqual('123')

--- a/spec/gist-spec.coffee
+++ b/spec/gist-spec.coffee
@@ -15,7 +15,6 @@ describe "Gist", ->
     atom.config.set('gist.tokenFile', '')
     atom.config.set('gist.environmentName', 'GIST_ACCESS_TOKEN')
     atom.config.set('gist.hostname', '')
-    atom.config.set('gist.hostnameFile', '')
 
     waitsForPromise ->
       atom.workspace.open().then((_editor) ->
@@ -52,12 +51,3 @@ describe "Gist", ->
 
     it "gist.hostname", ->
       expect(gistPackage.getHostname()).toEqual('abc')
-
-    it "gist.hostnameFile", ->
-      directory = temp.mkdirSync('atom-gist')
-      hostnameFile = path.join(directory, 'gist.hostname')
-      fs.writeFileSync(hostnameFile, '123')
-
-      expect(gistPackage.getHostname()).toEqual('abc')
-      atom.config.set('gist.hostnameFile', hostnameFile)
-      expect(gistPackage.getHostname()).toEqual('123')


### PR DESCRIPTION
I :heart: using [the gist package for Atom](https://atom.io/packages/gist) to create and edit Gists on GitHub.com!

I'd also like to use it to create and edit Gists on my GitHub Enterprise instance.

This PR adds configuration options for a custom hostname and updates README.md.