### PR TITLE
List first 100 Gists for user

### DIFF
--- a/lib/gist-client.coffee
+++ b/lib/gist-client.coffee
@@ -13,7 +13,7 @@ class GistClient
     @request('create', gist)
 
   list: (params...) ->
-    @request('list', params...)
+    @request('list', 1, 100, params...)
 
   get: (id) ->
     @request('get', id)


### PR DESCRIPTION
Add `page=1` and `per_page=100` parameters to the `.list()` call.

This way atom-gist can List the first 100, rather than the first 30, Gists for a user.

See also https://github.com/aki77/atom-gist/issues/24